### PR TITLE
Fix create record bug & and mismatched relations bug

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -63,7 +63,9 @@ class Extension extends BaseExtension
         if (isset($content['id'])) {
             $id = $content['id'];
             
-            $query = "SELECT * from bolt_relations WHERE from_id=$id AND from_contenttype='$relcontenttype' ORDER BY sort;";
+            $fromcontenttype = $content->contenttype['slug'];
+            
+            $query = "SELECT * from bolt_relations WHERE from_id=$id AND from_contenttype='$fromcontenttype' AND to_contenttype='$relcontenttype' ORDER BY sort;";
             $result = $this->app['db']->fetchAll($query);
             
             return $result;
@@ -77,7 +79,9 @@ class Extension extends BaseExtension
         if(isset($content['id'])){
             $id = $content['id'];
             
-            $query = "SELECT * from bolt_relations WHERE from_id=$id AND to_contenttype='$relcontenttype' ORDER BY sort;";
+            $fromcontenttype = $content->contenttype['slug'];
+            
+            $query = "SELECT * from bolt_relations WHERE from_id=$id AND from_contenttype='$fromcontenttype' AND to_contenttype='$relcontenttype' ORDER BY sort;";
             $result = $this->app['db']->fetchAll($query);
             
             $arr2 = $content->related();

--- a/Extension.php
+++ b/Extension.php
@@ -60,36 +60,43 @@ class Extension extends BaseExtension
     
     public function getSortedRelations($content, $relcontenttype)
     {
-        $id = $content['id'];
-        
-        $query = "SELECT * from bolt_relations WHERE from_id=$id AND from_contenttype='$relcontenttype' ORDER BY sort;";
-        $result = $this->app['db']->fetchAll($query);
-        
-        return $result;
+        if (isset($content['id'])) {
+            $id = $content['id'];
+            
+            $query = "SELECT * from bolt_relations WHERE from_id=$id AND from_contenttype='$relcontenttype' ORDER BY sort;";
+            $result = $this->app['db']->fetchAll($query);
+            
+            return $result;
+        } else {
+            return [];
+        }
     }
     
     public function getSortedRelated($content, $relcontenttype)
     {
-        $id = $content['id'];
-        
-        $query = "SELECT * from bolt_relations WHERE from_id=$id AND to_contenttype='$relcontenttype' ORDER BY sort;";
-        $result = $this->app['db']->fetchAll($query);
-        
-        $arr2 = $content->related();
-        $arr1 = $result;
-        
-        $index = [];
-        foreach ($arr2 as $key => $obj) {
-            $index[] = $obj->id;
+        if(isset($content['id'])){
+            $id = $content['id'];
+            
+            $query = "SELECT * from bolt_relations WHERE from_id=$id AND to_contenttype='$relcontenttype' ORDER BY sort;";
+            $result = $this->app['db']->fetchAll($query);
+            
+            $arr2 = $content->related();
+            $arr1 = $result;
+            
+            $index = [];
+            foreach ($arr2 as $key => $obj) {
+                $index[] = $obj->id;
+            }
+            $compiled = [];        
+            foreach ($arr1 as $val) {
+                $relatedId = $val['to_id'];
+                $compiled[] = $arr2[array_search($relatedId, $index)];
+            }
+            
+            return $compiled;
+        } else {
+            return [];
         }
-        $compiled = [];        
-        foreach ($arr1 as $val) {
-            $relatedId = $val['to_id'];
-            $compiled[] = $arr2[array_search($relatedId, $index)];
-        }
-        
-        
-        return $compiled;
     }
     
     public function saveRelationOrder($event)


### PR DESCRIPTION
This should fix two bugs:
1. Could not create a new record while it has `sortable: true` since the db query in `getSortedRelations` did not check if it had an id before running it's query.
2. In certain situations `getSortedRelations` and `getSortedRelated` would return other records relations since they didn't check both `from_contenttype` and `to_contenttype`
